### PR TITLE
Add public leads dashboard with filtering and Stripe purchase

### DIFF
--- a/templates/leads.html
+++ b/templates/leads.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Lead Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css"/>
+  <style>
+    :root { color-scheme: dark; }
+    .gradient{background:
+      radial-gradient(900px 480px at 10% -10%, #86efac33, transparent 60%),
+      radial-gradient(800px 520px at 110% 10%, #22d3ee33, transparent 60%),
+      linear-gradient(180deg,#0b1220 0%,#0b1220 60%,#0b1220 100%)}
+    .glass{background:rgba(255,255,255,.06);backdrop-filter:blur(10px)}
+    .btn{display:inline-flex;align-items:center;justify-content:center;border-radius:0.9rem;font-weight:600}
+    .btn-cyan{background:#22d3ee;color:#0b1220} .btn-cyan:hover{background:#06b6d4}
+  </style>
+</head>
+<body class="gradient text-gray-100 antialiased">
+  <header class="glass border-b border-white/10">
+    <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div class="w-9 h-9 bg-emerald-400 rounded-xl flex items-center justify-center font-black text-slate-900">TL</div>
+        <span class="font-semibold tracking-wide">Tree Lead Exchange</span>
+      </div>
+      <a href="/" class="text-gray-300 hover:text-white">Home</a>
+    </div>
+  </header>
+
+  <main class="max-w-6xl mx-auto px-4 py-10">
+    <div class="mb-4 flex flex-wrap gap-4 items-end">
+      <div>
+        <label for="categoryFilter" class="block text-sm mb-1">Category</label>
+        <select id="categoryFilter" class="bg-gray-800 text-white p-2 rounded">
+          <option value="">All</option>
+          {% for cat in categories %}
+          <option value="{{ cat }}">{{ cat }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label for="cityFilter" class="block text-sm mb-1">City/ZIP</label>
+        <input id="cityFilter" type="text" class="bg-gray-800 text-white p-2 rounded" placeholder="Search city or ZIP"/>
+      </div>
+    </div>
+
+    <table id="leadsTable" class="display stripe w-full text-sm">
+      <thead>
+        <tr>
+          <th>Category</th>
+          <th>Lead Age</th>
+          <th>City/ZIP</th>
+          <th>Description</th>
+          <th>Asking Price ($)</th>
+          <th>Created</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for lead in leads %}
+        <tr>
+          <td>{{ lead['Category'] }}</td>
+          <td>{{ lead['Lead Age'] }}</td>
+          <td>{{ lead['City/ZIP'] }}</td>
+          <td>{{ lead['Description'] }}</td>
+          <td>{{ lead['Asking Price ($)'] }}</td>
+          <td>{{ lead['Created 2'] }}</td>
+          <td><button data-uuid="{{ lead['uuid'] }}" class="purchase btn btn-cyan px-3 py-1">Purchase Lead</button></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </main>
+
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://js.stripe.com/v3/"></script>
+  <script>
+    $(document).ready(function() {
+      var table = $('#leadsTable').DataTable();
+      $('#categoryFilter').on('change', function(){
+        var val = $.fn.dataTable.util.escapeRegex($(this).val());
+        table.column(0).search(val ? '^'+val+'$' : '', true, false).draw();
+      });
+      $('#cityFilter').on('keyup change', function(){
+        table.column(2).search(this.value).draw();
+      });
+      var stripe = Stripe('{{ publishable_key }}');
+      $('#leadsTable').on('click', '.purchase', function(){
+        var uuid = $(this).data('uuid');
+        fetch('/create-checkout-session/' + uuid, {method: 'POST'})
+          .then(function(r){ return r.json(); })
+          .then(function(session){ return stripe.redirectToCheckout({ sessionId: session.id }); })
+          .catch(function(err){ console.error(err); });
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Expose `/leads` dashboard that lists Airtable leads with category, age, ZIP, description, price, and created timestamp
- Allow filtering by category and city/ZIP, plus global search via DataTables
- Enable Stripe checkout from dashboard and email lead details on success
- Add price fallback when creating checkout sessions

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b163d5bf7483248f5fb7225c6a1414